### PR TITLE
add: workflow added to push docker images to docker hub

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -1,9 +1,9 @@
-name: Publish Docker images for staging environment
+name: Publish Docker images for production environment
 
 on:
   push:
     branches:
-      - develop
+      - master
 
 jobs:
   push_api_image:
@@ -31,7 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:beta
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:latest
 
       - name: Build and push API Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
@@ -39,7 +39,7 @@ jobs:
           context: ./api
           file: ${{ steps.dockerfile.outputs.dockerfile }}
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:beta
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:latest
           labels: ${{ steps.meta.outputs.labels }}
 
   push_client_image:
@@ -67,7 +67,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:beta
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:latest
 
       - name: Build and push Client Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
@@ -75,5 +75,5 @@ jobs:
           context: ./client
           file: ${{ steps.dockerfile.outputs.dockerfile }}
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:beta
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:latest
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -1,0 +1,79 @@
+name: Publish Docker images for staging environment
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  push_api_image:
+    name: Push API Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Determine branch
+        id: branch
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+
+      - name: Set Dockerfile path for API
+        id: dockerfile
+        run: echo "::set-output name=dockerfile::api/Dockerfile"
+
+      - name: Extract metadata (tags, labels) for API Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:${{ steps.branch.outputs.branch }}
+
+      - name: Build and push API Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./api
+          file: ${{ steps.dockerfile.outputs.dockerfile }}
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:${{ steps.branch.outputs.branch }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  push_client_image:
+    name: Push Client Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Determine branch
+        id: branch
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+
+      - name: Set Dockerfile path for Client
+        id: dockerfile
+        run: echo "::set-output name=dockerfile::client/Dockerfile"
+
+      - name: Extract metadata (tags, labels) for Client Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:${{ steps.branch.outputs.branch }}
+
+      - name: Build and push Client Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./client
+          file: ${{ steps.dockerfile.outputs.dockerfile }}
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:${{ steps.branch.outputs.branch }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -31,7 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:${{ steps.branch.outputs.branch }}
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:test
 
       - name: Build and push API Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
@@ -39,7 +39,7 @@ jobs:
           context: ./api
           file: ${{ steps.dockerfile.outputs.dockerfile }}
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:${{ steps.branch.outputs.branch }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-api:test
           labels: ${{ steps.meta.outputs.labels }}
 
   push_client_image:
@@ -67,7 +67,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:${{ steps.branch.outputs.branch }}
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:test
 
       - name: Build and push Client Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
@@ -75,5 +75,5 @@ jobs:
           context: ./client
           file: ${{ steps.dockerfile.outputs.dockerfile }}
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:${{ steps.branch.outputs.branch }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/shm-client:test
           labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Extra
+docker-compose.yaml

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,4 +8,4 @@ COPY . .
 
 EXPOSE 5173
 
-CMD npm run dev
+CMD npm run dev -- --host

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /client
 
 COPY package*.json ./
 RUN npm ci
-
 COPY . .
 
-RUN npm run build
 EXPOSE 5173
 
 CMD npm run dev

--- a/compose-templates/development.yaml
+++ b/compose-templates/development.yaml
@@ -1,0 +1,38 @@
+services:
+  client:
+    container_name: client
+    build:
+      context: ./client
+    working_dir: /client
+    command: npm run dev -- --host
+    volumes:
+      - ./client:/client
+      - /client/node_modules
+    ports:
+      - "5173:5173"
+    restart: on-failure
+    networks:
+      - public_network
+    depends_on:
+      - api
+
+  api:
+    container_name: api
+    build:
+      context: ./api
+    working_dir: /api
+    command: uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
+    env_file:
+      - api/.env
+    volumes:
+      - ./api:/api
+    ports:
+      - "8000:8000"
+    restart: on-failure
+    networks:
+      - public_network
+      - private_network
+
+networks:
+  public_network:
+  private_network:

--- a/compose-templates/production.yaml
+++ b/compose-templates/production.yaml
@@ -1,0 +1,32 @@
+services:
+  client:
+    container_name: client
+    image: rifatrakib/shm-client:latest
+    volumes:
+      - ./client:/client
+      - /client/node_modules
+    ports:
+      - "5173:5173"
+    restart: on-failure
+    networks:
+      - public_network
+    depends_on:
+      - api
+
+  api:
+    container_name: api
+    image: rifatrakib/shm-api:latest
+    env_file:
+      - api/.env
+    volumes:
+      - ./api:/api
+    ports:
+      - "8000:8000"
+    restart: on-failure
+    networks:
+      - public_network
+      - private_network
+
+networks:
+  public_network:
+  private_network:

--- a/compose-templates/staging.yaml
+++ b/compose-templates/staging.yaml
@@ -1,0 +1,32 @@
+services:
+  client:
+    container_name: client
+    image: rifatrakib/shm-client:beta
+    volumes:
+      - ./client:/client
+      - /client/node_modules
+    ports:
+      - "5173:5173"
+    restart: on-failure
+    networks:
+      - public_network
+    depends_on:
+      - api
+
+  api:
+    container_name: api
+    image: rifatrakib/shm-api:beta
+    env_file:
+      - api/.env
+    volumes:
+      - ./api:/api
+    ports:
+      - "8000:8000"
+    restart: on-failure
+    networks:
+      - public_network
+      - private_network
+
+networks:
+  public_network:
+  private_network:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   client:
     container_name: client
-    image: rifatrakib/shm-client:test
+    image: rifatrakib/shm-client:beta
     volumes:
       - ./client:/client
       - /client/node_modules
@@ -15,7 +15,7 @@ services:
 
   api:
     container_name: api
-    image: rifatrakib/shm-api:test
+    image: rifatrakib/shm-api:beta
     env_file:
       - api/.env
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,7 @@
 services:
   client:
     container_name: client
-    build:
-      context: ./client
-    working_dir: /client
-    command: npm run dev -- --host
+    image: rifatrakib/shm-client:test
     volumes:
       - ./client:/client
       - /client/node_modules
@@ -18,10 +15,7 @@ services:
 
   api:
     container_name: api
-    build:
-      context: ./api
-    working_dir: /api
-    command: uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
+    image: rifatrakib/shm-api:test
     env_file:
       - api/.env
     volumes:


### PR DESCRIPTION
This PR accomplishes the following:

* Builds and pushes docker images to DockerHub repositories for develop and master branches having separate tags when new code is merged there from all PR in the future

Closes: [Add CI/CD workflows for both staging and production servers](https://github.com/rifatrakib/smart-housing-market/issues/6)